### PR TITLE
fix: placeholder visibility in contacts page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -549,15 +549,16 @@
               type="email"
               class="form-control"
               id="floatingInput"
-              placeholder="name@example.com"
+              placeholder="Email address"
             />
             <label for="floatingInput">Email address</label>
           </div>
           <div class="form-floating my-3">
             <textarea
               class="form-control"
-              placeholder="Leave a comment here"
+              placeholder="Comments"
               id="floatingTextarea2"
+              rows="3"
             ></textarea>
             <label for="floatingTextarea2">Comments</label>
           </div>


### PR DESCRIPTION
This PR fixes a minor bug in the contact us page where the placeholder and labels were colliding with each other.