### PR TITLE
Styles: Changing usability styles from about page

### DIFF
--- a/about.css
+++ b/about.css
@@ -1,24 +1,26 @@
 /* Custom Scrollbar Styling */
 ::-webkit-scrollbar-track {
-    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-    background-color: #F5F5F5;
+  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+  background-color: #f5f5f5;
 }
 
 ::-webkit-scrollbar {
-    width: 14px;
-    background-color: #F5F5F5;
+  width: 14px;
+  background-color: #f5f5f5;
 }
 
 ::-webkit-scrollbar-thumb {
-    background-color: rgba(217, 2, 2, 0.945);
-    background-image: -webkit-linear-gradient(45deg,
-                                              rgba(255, 255, 255, .2) 25%,
-                                              transparent 25%,
-                                              transparent 50%,
-                                              rgba(255, 255, 255, .2) 50%,
-                                              rgba(255, 255, 255, .2) 75%,
-                                              transparent 75%,
-                                              transparent)
+  background-color: rgba(217, 2, 2, 0.945);
+  background-image: -webkit-linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
 }
 
 /* Search Modal Styling */
@@ -80,16 +82,34 @@
 }
 
 h1 {
-    color: #eaeaea;
+  color: #eaeaea;
+}
+
+.fw-bold {
+  font-weight: bold;
+}
+
+.hover-effect {
+  box-shadow: 0px 3px 31px 3px #cf7b8a;
+}
+
+.hover-effect:hover {
+  transform: scale(1.15) !important;
+  transition: all 0.3s ease-in-out !important;
+}
+
+.hover-team:hover {
+  transform: scale(1.15) !important;
+  transition: all 0.3s ease-in-out !important;
 }
 
 @media only screen and (max-width: 767px) {
-    h1 {
-        font-size: 1.8rem;
-    }
+  h1 {
+    font-size: 1.8rem;
+  }
 
-    .classy-nav-container .classy-navbar .nav-brand {
-        max-width: fit-content;
-        margin-right: 15px;
-    }
+  .classy-nav-container .classy-navbar .nav-brand {
+    max-width: fit-content;
+    margin-right: 15px;
+  }
 }

--- a/about.html
+++ b/about.html
@@ -42,7 +42,7 @@
 
                         <form action="https://preview.colorlib.com/theme/alime/index.html" method="post">
                             <input type="search" name="top-search-bar" class="form-control"
-                                placeholder="Search and hit enter...">
+                                placeholder="Search anFd hit enter...">
                             <button type="submit">Search</button>
                         </form>
                     </div>
@@ -123,22 +123,22 @@
                     <div class="about-us-content mb-80">
                         <h3 data-aos="fade-up" data-aos-duration="3000">We Live For Passion</h3>
                         <div class="line" data-aos="fade-up" data-aos-duration="3000"></div>
-                        <p class="simple-text-color" data-aos="fade-up" data-aos-duration="3000">Passion is energy so better to
+                        <p class="simple-text-color fw-bold" data-aos="fade-up" data-aos-duration="3000">Passion is energy so better to
                             focus on the
                             things which excites us. So, that we can perform our best at that. We should never
                             compromise on our passion for anything.</p>
-                        <p class="simple-text-color" data-aos="fade-up" data-aos-duration="3000">Being passionate requires
+                        <p class="simple-text-color fw-bold" data-aos="fade-up" data-aos-duration="3000">Being passionate requires
                             dedication, hard work,
                             focus, and the willingness to fail over and over again. However, if you're ready to put in
                             the work, then being a passionate person who knows what he wants can bring excitement, joy,
                             and a sense of true purpose to your life.</p>
-                        <p class="simple-text-color" data-aos="fade-up" data-aos-duration="3000">One must always live for their
+                        <p class="simple-text-color fw-bold" data-aos="fade-up" data-aos-duration="3000">One must always live for their
                             passion because it
                             is said that one person with passion is better than hundreds merely interested. Knowledge
                             can be taught, Skills can be
                             acquired and experience is earned in time, but it's very hard to make someone passionate
                             about something , hence passion is priceless.</p>
-                        <a class="btn alime-btn btn-2 mt-30" data-aos="fade-up" data-aos-duration="3000"
+                        <a class="btn alime-btn btn-2 mt-30 hover-effect" data-aos="fade-up" data-aos-duration="3000"
                             href="contact.html">Contact Us</a>
                     </div>
                 </div>
@@ -173,7 +173,7 @@
                             <i class="fa fa-film" aria-hidden="true"></i>
                         </div>
                         <h4>High Quality Images</h4>
-                        <p>Images and photography fascinates everybody but we believe in quality and provide High
+                        <p class="fw-bold">Images and photography fascinates everybody but we believe in quality and provide High
                             quality images which are best to see, to show, to set. </p>
                     </div>
                 </div>
@@ -184,7 +184,7 @@
                             <i class="fa fa-pencil" aria-hidden="true"></i>
                         </div>
                         <h4>Abundant Experience</h4>
-                        <p>Experiences makes a man perfect at everything. With a sufficient abundant experienced
+                        <p class="fw-bold">Experiences makes a man perfect at everything. With a sufficient abundant experienced
                             phtographers we provide you the best images.</p>
                     </div>
                 </div>
@@ -195,7 +195,7 @@
                             <i class="fa fa-camera" aria-hidden="true"></i>
                         </div>
                         <h4>Modern Equipments</h4>
-                        <p>With modern and updated equipments we are able to capture every moment in an attractive
+                        <p class="fw-bold">With modern and updated equipments we are able to capture every moment in an attractive
                             manner. We use latest equipments.</p>
                     </div>
                 </div>
@@ -215,7 +215,7 @@
             </div>
             <div class="row">
 
-                <div class="col-md-6 col-xl-3">
+                <div class="col-md-6 col-xl-3 hover-team">
                     <div class="team-content-area text-center mb-30" data-aos="fade-up" data-aos-duration="3000">
                         <div class="member-thumb">
                             <img src="img/bg-img/19.jpg" alt="">
@@ -235,7 +235,7 @@
                     </div>
                 </div>
 
-                <div class="col-md-6 col-xl-3">
+                <div class="col-md-6 col-xl-3 hover-team">
                     <div class="team-content-area text-center mb-30" data-aos="fade-up" data-aos-duration="3000">
                         <div class="member-thumb">
                             <img src="img/bg-img/20.jpg" alt="">
@@ -255,7 +255,7 @@
                     </div>
                 </div>
 
-                <div class="col-md-6 col-xl-3">
+                <div class="col-md-6 col-xl-3 hover-team">
                     <div class="team-content-area text-center mb-30" data-aos="fade-up" data-aos-duration="3000">
                         <div class="member-thumb">
                             <img src="img/bg-img/21.jpg" alt="">
@@ -275,7 +275,7 @@
                     </div>
                 </div>
 
-                <div class="col-md-6 col-xl-3">
+                <div class="col-md-6 col-xl-3 hover-team">
                     <div class="team-content-area text-center mb-30" data-aos="fade-up" data-aos-duration="3000">
                         <div class="member-thumb">
                             <img src="img/bg-img/22.jpg" alt="">


### PR DESCRIPTION
### What's new 

Improved some styles from about page to perfom the user experience!

### What was changed? 

###  First of all I've changed the vast majority of the text from the about page to become easier to read. Last version was hard to read with the background. Check the image below:
<img width="1899" height="904" alt="Captura de tela 2025-10-23 231716" src="https://github.com/user-attachments/assets/02943750-a456-468b-bf5e-7f9257f64e31" />

<img width="1908" height="883" alt="Captura de tela 2025-10-23 234118" src="https://github.com/user-attachments/assets/8e3060d9-8870-494b-9f9d-626e860de0a0" />

Was added a bold weight to the text.

### Adding a more intuitive "contact us" button with a slight pink shadow and a hover re scaling the size

<img width="988" height="466" alt="Captura de tela 2025-10-23 235348" src="https://github.com/user-attachments/assets/92c4341d-9e40-4466-b34c-b3f29f9efd21" />

### Added smoth scale hover animation to authors 

<img width="1918" height="909" alt="Captura de tela 2025-10-23 234425" src="https://github.com/user-attachments/assets/44d28ba7-924c-4a57-905a-ecb3850b4e52" />

### This pull request closes #178 




